### PR TITLE
Project1

### DIFF
--- a/doc/develop/project1.md
+++ b/doc/develop/project1.md
@@ -1,0 +1,57 @@
+# Project1
+
+## 目标
+
+1. 实现standaloneKV
+2. 实现raw_api，完成测试
+
+## 具体实现
+
+### standalone_stirage
+需要实现的代码放在`kv/storage/standalone_storage/standalone_storage.go`，需要实现`StandAloneStorage`结构体，方法都已经定义好了，仅需要实现。这其实是一个简化的`raft_storage`，只要取其中一部分就行了，其余不懂的api参考`engine_util`就行了。
+
+- 对于`StandAloneStorage`结构体来说，其实一个`engines`就足够了，调用一个包装好的`badger`数据库。
+- `Start`方法，没有需要实现的内容
+- `Stop`关闭数据库
+- `Write`可以参考`engine_util.write_batch.go`，它其实就是把`batch`数组转化为一个`WriteBatch`，可以进行批处理写入数据库
+- `Reader`可以参考`raft_storage`，需要一个`badger.txn`处理一致性，对于`Reader`来说需要返回一个对象实现`StorageReader`，这里新建一个对象文件`reader.go`可以参考`region_reader.go`。这里需要产生一个迭代器，我们这个迭代器比较简单直接使用`cf_iterator.go`就可以了。
+
+### raw_api
+需要实现的代码放在`kv/server/raw_api.go`，我们需要实现4个api，RawGet/ RawScan/ RawPut/ RawDelete
+- RawGet, 比较简单，注意返回类型，空值需要额外标注
+- RawPut，比较简单，利用`Storage.Modify`包装原有request中的（key,value）即可
+- RawDelet，和RawPut类似
+- RawScan，这个基于我们已经写的`reader.go`，特别注意，当得到迭代器的时候，需要`seek`到对应的`start_key`，不然找不到值。需要注意，limit的大小
+
+## 测试方法
+
+`make project1`
+
+## 测试结果
+
+```
+➜ make project1                     
+GO111MODULE=on go test -v --count=1 --parallel=1 -p=1 ./kv/server -run 1
+=== RUN   TestRawGet1
+--- PASS: TestRawGet1 (0.95s)
+=== RUN   TestRawGetNotFound1
+--- PASS: TestRawGetNotFound1 (0.89s)
+=== RUN   TestRawPut1
+--- PASS: TestRawPut1 (0.48s)
+=== RUN   TestRawGetAfterRawPut1
+--- PASS: TestRawGetAfterRawPut1 (0.55s)
+=== RUN   TestRawGetAfterRawDelete1
+--- PASS: TestRawGetAfterRawDelete1 (0.85s)
+=== RUN   TestRawDelete1
+--- PASS: TestRawDelete1 (0.60s)
+=== RUN   TestRawScan1
+--- PASS: TestRawScan1 (1.07s)
+=== RUN   TestRawScanAfterRawPut1
+--- PASS: TestRawScanAfterRawPut1 (0.87s)
+=== RUN   TestRawScanAfterRawDelete1
+--- PASS: TestRawScanAfterRawDelete1 (0.99s)
+=== RUN   TestIterWithRawDelete1
+--- PASS: TestIterWithRawDelete1 (0.89s)
+PASS
+ok      github.com/pingcap-incubator/tinykv/kv/server   8.147s
+```

--- a/kv/server/raw_api.go
+++ b/kv/server/raw_api.go
@@ -17,8 +17,7 @@ func (server *Server) RawGet(_ context.Context, req *kvrpcpb.RawGetRequest) (*kv
 	if err != nil {
 		return nil, err
 	}
-	cf := req.Cf
-	key := req.Key
+	cf, key := req.Cf, req.Key
 	value, err := reader.GetCF(cf, key)
 	if err != nil {
 		return nil, err
@@ -37,9 +36,7 @@ func (server *Server) RawGet(_ context.Context, req *kvrpcpb.RawGetRequest) (*kv
 func (server *Server) RawPut(_ context.Context, req *kvrpcpb.RawPutRequest) (*kvrpcpb.RawPutResponse, error) {
 	// Your Code Here (1).
 	// Hint: Consider using Storage.Modify to store data to be modified
-	cf := req.Cf
-	key := req.Key
-	value := req.Value
+	cf, key, value := req.Cf, req.Key, req.Value
 	modify := []storage.Modify{
 		{
 			Data: storage.Put{
@@ -60,8 +57,7 @@ func (server *Server) RawPut(_ context.Context, req *kvrpcpb.RawPutRequest) (*kv
 func (server *Server) RawDelete(_ context.Context, req *kvrpcpb.RawDeleteRequest) (*kvrpcpb.RawDeleteResponse, error) {
 	// Your Code Here (1).
 	// Hint: Consider using Storage.Modify to store data to be deleted
-	cf := req.Cf
-	key := req.Key
+	cf, key := req.Cf, req.Key
 	modify := []storage.Modify{
 		{
 			Data: storage.Delete{

--- a/kv/server/raw_api.go
+++ b/kv/server/raw_api.go
@@ -2,6 +2,8 @@ package server
 
 import (
 	"context"
+
+	"github.com/pingcap-incubator/tinykv/kv/storage"
 	"github.com/pingcap-incubator/tinykv/proto/pkg/kvrpcpb"
 )
 
@@ -11,26 +13,96 @@ import (
 // RawGet return the corresponding Get response based on RawGetRequest's CF and Key fields
 func (server *Server) RawGet(_ context.Context, req *kvrpcpb.RawGetRequest) (*kvrpcpb.RawGetResponse, error) {
 	// Your Code Here (1).
-	return nil, nil
+	reader, err := server.storage.Reader(nil)
+	if err != nil {
+		return nil, err
+	}
+	cf := req.Cf
+	key := req.Key
+	value, err := reader.GetCF(cf, key)
+	if err != nil {
+		return nil, err
+	}
+	resp := kvrpcpb.RawGetResponse{}
+	if value == nil {
+		resp.NotFound = true
+	} else {
+		resp.Value = append(resp.Value, value...)
+	}
+	reader.Close()
+	return &resp, nil
 }
 
 // RawPut puts the target data into storage and returns the corresponding response
 func (server *Server) RawPut(_ context.Context, req *kvrpcpb.RawPutRequest) (*kvrpcpb.RawPutResponse, error) {
 	// Your Code Here (1).
 	// Hint: Consider using Storage.Modify to store data to be modified
-	return nil, nil
+	cf := req.Cf
+	key := req.Key
+	value := req.Value
+	modify := []storage.Modify{
+		{
+			Data: storage.Put{
+				Key:   key,
+				Value: value,
+				Cf:    cf,
+			},
+		},
+	}
+	if err := server.storage.Write(nil, modify); err != nil {
+		return nil, err
+	}
+	resp := kvrpcpb.RawPutResponse{}
+	return &resp, nil
 }
 
 // RawDelete delete the target data from storage and returns the corresponding response
 func (server *Server) RawDelete(_ context.Context, req *kvrpcpb.RawDeleteRequest) (*kvrpcpb.RawDeleteResponse, error) {
 	// Your Code Here (1).
 	// Hint: Consider using Storage.Modify to store data to be deleted
-	return nil, nil
+	cf := req.Cf
+	key := req.Key
+	modify := []storage.Modify{
+		{
+			Data: storage.Delete{
+				Key: key,
+				Cf:  cf,
+			},
+		},
+	}
+	if err := server.storage.Write(nil, modify); err != nil {
+		return nil, err
+	}
+	resp := kvrpcpb.RawDeleteResponse{}
+	return &resp, nil
 }
 
 // RawScan scan the data starting from the start key up to limit. and return the corresponding result
 func (server *Server) RawScan(_ context.Context, req *kvrpcpb.RawScanRequest) (*kvrpcpb.RawScanResponse, error) {
 	// Your Code Here (1).
 	// Hint: Consider using reader.IterCF
-	return nil, nil
+	cf, startKey, limit := req.Cf, req.StartKey, req.Limit
+
+	reader, err := server.storage.Reader(nil)
+	if err != nil {
+		return nil, err
+	}
+
+	it := reader.IterCF(cf)
+	it.Seek(startKey)
+
+	kvs := []*kvrpcpb.KvPair{}
+	for ; it.Valid() && len(kvs) < int(limit); it.Next() {
+		key := it.Item().KeyCopy(nil)
+
+		value, err := it.Item().ValueCopy(nil)
+		if err != nil {
+			return nil, err
+		}
+		kvs = append(kvs, &kvrpcpb.KvPair{Key: key, Value: value})
+
+	}
+	it.Close()
+	resp := kvrpcpb.RawScanResponse{Kvs: kvs}
+	return &resp, nil
 }

--- a/kv/storage/standalone_storage/reader.go
+++ b/kv/storage/standalone_storage/reader.go
@@ -1,0 +1,65 @@
+package standalone_storage
+
+import (
+	"github.com/Connor1996/badger"
+	"github.com/pingcap-incubator/tinykv/kv/util/engine_util"
+)
+
+type Reader struct {
+	txn *badger.Txn
+}
+
+func NewReader(txn *badger.Txn) *Reader {
+	return &Reader{
+		txn: txn,
+	}
+}
+
+func (r *Reader) GetCF(cf string, key []byte) ([]byte, error) {
+	val, err := engine_util.GetCFFromTxn(r.txn, cf, key)
+	if err == badger.ErrKeyNotFound {
+		return nil, nil
+	}
+	return val, err
+}
+
+func (r *Reader) IterCF(cf string) engine_util.DBIterator {
+	return engine_util.NewCFIterator(cf, r.txn)
+	// 这部分代码就是对`NewCFIterator`外套了一层，没有拓展的功能可以省略
+	// return NewReaderIterator(engine_util.NewCFIterator(cf, r.txn))
+}
+
+func (r *Reader) Close() {
+	r.txn.Discard()
+}
+
+// 这部分代码就是对`NewCFIterator`外套了一层，没有拓展的功能可以省略
+// type ReaderIterator struct {
+// 	iter *engine_util.BadgerIterator
+// }
+
+// func NewReaderIterator(iter *engine_util.BadgerIterator) *ReaderIterator {
+// 	return &ReaderIterator{
+// 		iter: iter,
+// 	}
+// }
+
+// func (ri *ReaderIterator) Item() engine_util.DBItem {
+// 	return ri.iter.Item()
+// }
+
+// func (ri *ReaderIterator) Close() {
+// 	ri.iter.Close()
+// }
+
+// func (ri *ReaderIterator) Valid() bool {
+// 	return ri.iter.Valid()
+// }
+
+// func (ri *ReaderIterator) Next() {
+// 	ri.iter.Next()
+// }
+
+// func (ri *ReaderIterator) Seek(key []byte) {
+// 	ri.iter.Seek(key)
+// }

--- a/kv/storage/standalone_storage/standalone_storage.go
+++ b/kv/storage/standalone_storage/standalone_storage.go
@@ -1,8 +1,13 @@
 package standalone_storage
 
 import (
+	"os"
+	"path/filepath"
+
+	"github.com/Connor1996/badger"
 	"github.com/pingcap-incubator/tinykv/kv/config"
 	"github.com/pingcap-incubator/tinykv/kv/storage"
+	"github.com/pingcap-incubator/tinykv/kv/util/engine_util"
 	"github.com/pingcap-incubator/tinykv/proto/pkg/kvrpcpb"
 )
 
@@ -10,11 +15,20 @@ import (
 // communicate with other nodes and all data is stored locally.
 type StandAloneStorage struct {
 	// Your Data Here (1).
+	engines *badger.DB
+	config  *config.Config
 }
 
 func NewStandAloneStorage(conf *config.Config) *StandAloneStorage {
 	// Your Code Here (1).
-	return nil
+	dbPath := conf.DBPath
+	kvPath := filepath.Join(dbPath, "kv")
+
+	os.Mkdir(kvPath, os.ModePerm)
+
+	kvDB := engine_util.CreateDB(kvPath, false)
+
+	return &StandAloneStorage{engines: kvDB, config: conf}
 }
 
 func (s *StandAloneStorage) Start() error {
@@ -24,15 +38,35 @@ func (s *StandAloneStorage) Start() error {
 
 func (s *StandAloneStorage) Stop() error {
 	// Your Code Here (1).
+
+	if err := s.engines.Close(); err != nil {
+		return err
+	}
 	return nil
 }
 
 func (s *StandAloneStorage) Reader(ctx *kvrpcpb.Context) (storage.StorageReader, error) {
 	// Your Code Here (1).
-	return nil, nil
+	txn := s.engines.NewTransaction(false)
+	reader := NewReader(txn)
+	return reader, nil
 }
 
 func (s *StandAloneStorage) Write(ctx *kvrpcpb.Context, batch []storage.Modify) error {
 	// Your Code Here (1).
+	wbatch := new(engine_util.WriteBatch)
+	for _, m := range batch {
+		switch m.Data.(type) {
+		case storage.Put:
+			put := m.Data.(storage.Put)
+			wbatch.SetCF(put.Cf, put.Key, put.Value)
+		case storage.Delete:
+			delete := m.Data.(storage.Delete)
+			wbatch.DeleteCF(delete.Cf, delete.Key)
+		}
+	}
+	if err := wbatch.WriteToDB(s.engines); err != nil {
+		return err
+	}
 	return nil
 }


### PR DESCRIPTION
# Project1

## 目标

1. 实现standaloneKV
2. 实现raw_api，完成测试

## 具体实现

### standalone_stirage
需要实现的代码放在`kv/storage/standalone_storage/standalone_storage.go`，需要实现`StandAloneStorage`结构体，方法都已经定义好了，仅需要实现。这其实是一个简化的`raft_storage`，只要取其中一部分就行了，其余不懂的api参考`engine_util`就行了。

- 对于`StandAloneStorage`结构体来说，其实一个`engines`就足够了，调用一个包装好的`badger`数据库。
- `Start`方法，没有需要实现的内容
- `Stop`关闭数据库
- `Write`可以参考`engine_util.write_batch.go`，它其实就是把`batch`数组转化为一个`WriteBatch`，可以进行批处理写入数据库
- `Reader`可以参考`raft_storage`，需要一个`badger.txn`处理一致性，对于`Reader`来说需要返回一个对象实现`StorageReader`，这里新建一个对象文件`reader.go`可以参考`region_reader.go`。这里需要产生一个迭代器，我们这个迭代器比较简单直接使用`cf_iterator.go`就可以了。

### raw_api
需要实现的代码放在`kv/server/raw_api.go`，我们需要实现4个api，RawGet/ RawScan/ RawPut/ RawDelete
- RawGet, 比较简单，注意返回类型，空值需要额外标注
- RawPut，比较简单，利用`Storage.Modify`包装原有request中的（key,value）即可
- RawDelet，和RawPut类似
- RawScan，这个基于我们已经写的`reader.go`，特别注意，当得到迭代器的时候，需要`seek`到对应的`start_key`，不然找不到值。需要注意，limit的大小

## 测试方法

`make project1`

## 测试结果

```
➜ make project1                     
GO111MODULE=on go test -v --count=1 --parallel=1 -p=1 ./kv/server -run 1
=== RUN   TestRawGet1
--- PASS: TestRawGet1 (0.95s)
=== RUN   TestRawGetNotFound1
--- PASS: TestRawGetNotFound1 (0.89s)
=== RUN   TestRawPut1
--- PASS: TestRawPut1 (0.48s)
=== RUN   TestRawGetAfterRawPut1
--- PASS: TestRawGetAfterRawPut1 (0.55s)
=== RUN   TestRawGetAfterRawDelete1
--- PASS: TestRawGetAfterRawDelete1 (0.85s)
=== RUN   TestRawDelete1
--- PASS: TestRawDelete1 (0.60s)
=== RUN   TestRawScan1
--- PASS: TestRawScan1 (1.07s)
=== RUN   TestRawScanAfterRawPut1
--- PASS: TestRawScanAfterRawPut1 (0.87s)
=== RUN   TestRawScanAfterRawDelete1
--- PASS: TestRawScanAfterRawDelete1 (0.99s)
=== RUN   TestIterWithRawDelete1
--- PASS: TestIterWithRawDelete1 (0.89s)
PASS
ok      github.com/pingcap-incubator/tinykv/kv/server   8.147s
```